### PR TITLE
Basic control flow

### DIFF
--- a/src/main/java/me/august/lumen/common/BytecodeUtil.java
+++ b/src/main/java/me/august/lumen/common/BytecodeUtil.java
@@ -356,4 +356,30 @@ public final class BytecodeUtil implements Opcodes {
             false
         );
     }
+
+    public static int negateCondition(int opcode) {
+        switch (opcode) {
+            case IFNULL:    return IFNONNULL;
+            case IFNONNULL: return IFNULL;
+
+            case IFEQ:      return IFNE;
+            case IFNE:      return IFEQ;
+            case IFLT:      return IFGE;
+            case IFLE:      return IFGT;
+            case IFGT:      return IFLE;
+            case IFGE:      return IFLT;
+
+            case IF_ICMPEQ: return IF_ICMPNE;
+            case IF_ICMPNE: return IF_ICMPEQ;
+            case IF_ICMPLT: return IF_ICMPGE;
+            case IF_ICMPLE: return IF_ICMPGT;
+            case IF_ICMPGT: return IF_ICMPLE;
+            case IF_ICMPGE: return IF_ICMPLT;
+
+            case IF_ACMPEQ: return IF_ACMPNE;
+            case IF_ACMPNE: return IF_ACMPEQ;
+
+            default:        return -1;
+        }
+    }
 }

--- a/src/main/java/me/august/lumen/common/BytecodeUtil.java
+++ b/src/main/java/me/august/lumen/common/BytecodeUtil.java
@@ -325,6 +325,10 @@ public final class BytecodeUtil implements Opcodes {
         return type.equals(STRING_TYPE);
     }
 
+    public static boolean isObject(Type type) {
+        return type.getSort() == Type.OBJECT;
+    }
+
     private static final Type SB_TYPE = Type.getType(StringBuilder.class);
 
     public static void concatStringsBytecode(MethodVisitor method, BuildContext ctx, Expression... exprs) {

--- a/src/main/java/me/august/lumen/common/BytecodeUtil.java
+++ b/src/main/java/me/august/lumen/common/BytecodeUtil.java
@@ -386,4 +386,13 @@ public final class BytecodeUtil implements Opcodes {
             default:        return -1;
         }
     }
+
+    public static int compareOpcode(Type type) {
+        switch (type.getSort()) {
+            case Type.DOUBLE: return DCMPL;
+            case Type.FLOAT:  return FCMPL;
+            case Type.LONG:   return LCMP;
+            default:          return -1;
+        }
+    }
 }

--- a/src/main/java/me/august/lumen/compile/analyze/method/MethodReference.java
+++ b/src/main/java/me/august/lumen/compile/analyze/method/MethodReference.java
@@ -36,6 +36,10 @@ public abstract class MethodReference implements MethodCodeGen {
         }
     }
 
+    public Type getReturnType() {
+        return descriptor.getReturnType();
+    }
+
     public static class Instance extends MethodReference {
         public Instance(String owner, String name, Type descriptor) {
             super(owner, name, descriptor);

--- a/src/main/java/me/august/lumen/compile/codegen/Branch.java
+++ b/src/main/java/me/august/lumen/compile/codegen/Branch.java
@@ -20,6 +20,38 @@ public class Branch implements MethodCodeGen {
         this.elseBranch = elseBranch;
     }
 
+    public MethodCodeGen getCond() {
+        return cond;
+    }
+
+    public void setCond(MethodCodeGen cond) {
+        this.cond = cond;
+    }
+
+    public Label getElseJump() {
+        return elseJump;
+    }
+
+    public void setElseJump(Label elseJump) {
+        this.elseJump = elseJump;
+    }
+
+    public MethodCodeGen getIfBranch() {
+        return ifBranch;
+    }
+
+    public void setIfBranch(MethodCodeGen ifBranch) {
+        this.ifBranch = ifBranch;
+    }
+
+    public MethodCodeGen getElseBranch() {
+        return elseBranch;
+    }
+
+    public void setElseBranch(MethodCodeGen elseBranch) {
+        this.elseBranch = elseBranch;
+    }
+
     @Override
     public void generate(MethodVisitor visitor, BuildContext context) {
         cond.generate(visitor, context);

--- a/src/main/java/me/august/lumen/compile/codegen/Branch.java
+++ b/src/main/java/me/august/lumen/compile/codegen/Branch.java
@@ -1,0 +1,42 @@
+package me.august.lumen.compile.codegen;
+
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class Branch implements MethodCodeGen {
+
+    private MethodCodeGen cond;
+
+    private Label elseJump;
+
+    private MethodCodeGen ifBranch;
+    private MethodCodeGen elseBranch;
+
+    public Branch(MethodCodeGen cond, Label elseJump, MethodCodeGen ifBranch, MethodCodeGen elseBranch) {
+        this.cond = cond;
+        this.elseJump = elseJump;
+        this.ifBranch = ifBranch;
+        this.elseBranch = elseBranch;
+    }
+
+    @Override
+    public void generate(MethodVisitor visitor, BuildContext context) {
+        cond.generate(visitor, context);
+        ifBranch.generate(visitor, context);
+
+        Label avoidElse = null;
+        if (elseBranch != null) {
+            avoidElse = new Label();
+            visitor.visitJumpInsn(Opcodes.GOTO, avoidElse);
+        }
+
+        visitor.visitLabel(elseJump);
+
+        if (elseBranch != null) {
+            elseBranch.generate(visitor, context);
+            visitor.visitLabel(avoidElse);
+        }
+    }
+
+}

--- a/src/main/java/me/august/lumen/compile/codegen/Conditional.java
+++ b/src/main/java/me/august/lumen/compile/codegen/Conditional.java
@@ -1,0 +1,15 @@
+package me.august.lumen.compile.codegen;
+
+import org.objectweb.asm.Opcodes;
+
+public interface Conditional {
+
+    public static final MethodCodeGen PUSH_TRUE  =
+        (m, c) -> m.visitInsn(Opcodes.ICONST_1);
+
+    public static final MethodCodeGen PUSH_FALSE =
+        (m, c) -> m.visitInsn(Opcodes.ICONST_0);
+
+    Branch branch(MethodCodeGen ifBranch, MethodCodeGen elseBranch);
+
+}

--- a/src/main/java/me/august/lumen/compile/parser/Parser.java
+++ b/src/main/java/me/august/lumen/compile/parser/Parser.java
@@ -660,6 +660,8 @@ public class Parser {
             return parsePostfix();
         } else if (accept(BIT_COMP)) { // bitwise complement
             return new BitwiseComplementExpr(parsePostfix());
+        } else if (accept(NOT)) {
+            return new NotExpr(parsePostfix());
         } else if (accept(INC)) {
             return new IncrementExpr(parsePostfix(), IncrementExpr.Op.INC, false);
         } else if (accept(DEC)) {

--- a/src/main/java/me/august/lumen/compile/parser/Parser.java
+++ b/src/main/java/me/august/lumen/compile/parser/Parser.java
@@ -345,7 +345,11 @@ public class Parser {
         Body body;
         if (accept(THEN_KEYWORD)) {
             body = new Body(Arrays.asList(parseExpression()));
-            return new IfStmt(condition, body, new ArrayList<>(), null);
+            Body elseBody = null;
+            if (accept(ELSE_KEYWORD)) {
+                elseBody = new Body(Arrays.asList(parseExpression()));
+            }
+            return new IfStmt(condition, body, new ArrayList<>(), elseBody);
         }
 
         body = parseBody();

--- a/src/main/java/me/august/lumen/compile/parser/Parser.java
+++ b/src/main/java/me/august/lumen/compile/parser/Parser.java
@@ -547,13 +547,16 @@ public class Parser {
         Expression left = parseShift();
 
         Type peek = peek().getType();
-        if (peek == Type.LT || peek == Type.GT || peek == Type.LTE ||
-            peek == Type.GTE || peek == Type.INSTANCEOF_KEYWORD) {
+        if (peek == LT || peek == GT || peek == LTE || peek == GTE ||
+            peek == INSTANCEOF_KEYWORD || peek == NOT_INSTANCEOF_KEYWORD) {
             next(); // consume
 
             if (peek == INSTANCEOF_KEYWORD) {
                 String type = next().expectType(IDENTIFIER).getContent();
                 return new InstanceofExpr(left, type);
+            } else if (peek == NOT_INSTANCEOF_KEYWORD) {
+                String type = next().expectType(IDENTIFIER).getContent();
+                return new NotExpr(new InstanceofExpr(left, type));
             } else {
                 RelExpr.Op op = RelExpr.Op.valueOf(peek.name());
                 Expression right = parseExpression();

--- a/src/main/java/me/august/lumen/compile/parser/ast/expr/EqExpr.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/expr/EqExpr.java
@@ -1,6 +1,16 @@
 package me.august.lumen.compile.parser.ast.expr;
 
-public class EqExpr extends BinaryExpression {
+import com.sun.org.apache.bcel.internal.generic.IFNONNULL;
+import jdk.internal.org.objectweb.asm.Type;
+import me.august.lumen.compile.codegen.Branch;
+import me.august.lumen.compile.codegen.BuildContext;
+import me.august.lumen.compile.codegen.Conditional;
+import me.august.lumen.compile.codegen.MethodCodeGen;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class EqExpr extends BinaryExpression implements Conditional {
 
     public enum Op {
         EQ, NE
@@ -12,4 +22,31 @@ public class EqExpr extends BinaryExpression {
         super(left, right);
         this.op = op;
     }
+
+    @Override
+    public Branch branch(MethodCodeGen ifBranch, MethodCodeGen elseBranch) {
+        Label label = new Label();
+        MethodCodeGen cond = null;
+        if (left instanceof NullExpr && right.expressionType().getSort() == Type.OBJECT) {
+            int opcode = op == Op.EQ ? Opcodes.IFNONNULL : Opcodes.IFNULL;
+            cond = (m, c) -> {
+                right.generate(m, c);
+                m.visitJumpInsn(opcode, label);
+            };
+        } else if (right instanceof NullExpr && left.expressionType().getSort() == Type.OBJECT) {
+            int opcode = op == Op.EQ ? Opcodes.IFNONNULL : Opcodes.IFNULL;
+            cond = (m, c) -> {
+                left.generate(m, c);
+                m.visitJumpInsn(opcode, label);
+            };
+        }
+
+        return new Branch(cond, label, ifBranch, elseBranch);
+    }
+
+    @Override
+    public void generate(MethodVisitor visitor, BuildContext context) {
+        branch(Conditional.PUSH_TRUE, Conditional.PUSH_FALSE).generate(visitor, context);
+    }
+
 }

--- a/src/main/java/me/august/lumen/compile/parser/ast/expr/FalseExpr.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/expr/FalseExpr.java
@@ -1,5 +1,8 @@
 package me.august.lumen.compile.parser.ast.expr;
 
+import me.august.lumen.compile.codegen.BuildContext;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 public class FalseExpr extends TerminalExpression {
@@ -7,6 +10,11 @@ public class FalseExpr extends TerminalExpression {
     @Override
     public boolean isConstant() {
         return true;
+    }
+
+    @Override
+    public void generate(MethodVisitor visitor, BuildContext context) {
+        visitor.visitInsn(Opcodes.ICONST_0); // load 0 (false)
     }
 
     @Override

--- a/src/main/java/me/august/lumen/compile/parser/ast/expr/MethodCallExpr.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/expr/MethodCallExpr.java
@@ -4,6 +4,7 @@ import me.august.lumen.compile.analyze.method.MethodReference;
 import me.august.lumen.compile.codegen.BuildContext;
 import me.august.lumen.compile.parser.ast.Popable;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 import java.util.List;
 
@@ -42,6 +43,11 @@ public class MethodCallExpr extends TerminalExpression implements OwnedExpr, Pop
 
     public void setRef(MethodReference ref) {
         this.ref = ref;
+    }
+
+    @Override
+    public Type expressionType() {
+        return ref.getReturnType();
     }
 
     @Override

--- a/src/main/java/me/august/lumen/compile/parser/ast/expr/NotExpr.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/expr/NotExpr.java
@@ -7,6 +7,7 @@ import me.august.lumen.compile.codegen.MethodCodeGen;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 public class NotExpr implements Expression, Conditional {
 
@@ -24,6 +25,11 @@ public class NotExpr implements Expression, Conditional {
             m.visitJumpInsn(Opcodes.IFNE, label);
         };
         return new Branch(cond, label, ifBranch, elseBranch);
+    }
+
+    @Override
+    public Type expressionType() {
+        return Type.BOOLEAN_TYPE;
     }
 
     @Override

--- a/src/main/java/me/august/lumen/compile/parser/ast/expr/NotExpr.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/expr/NotExpr.java
@@ -1,0 +1,38 @@
+package me.august.lumen.compile.parser.ast.expr;
+
+import me.august.lumen.compile.codegen.Branch;
+import me.august.lumen.compile.codegen.BuildContext;
+import me.august.lumen.compile.codegen.Conditional;
+import me.august.lumen.compile.codegen.MethodCodeGen;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public class NotExpr implements Expression, Conditional {
+
+    private Expression value;
+
+    public NotExpr(Expression value) {
+        this.value = value;
+    }
+
+    @Override
+    public Branch branch(MethodCodeGen ifBranch, MethodCodeGen elseBranch) {
+        Label label = new Label();
+        MethodCodeGen cond = (m, c) -> {
+            value.generate(m, c);
+            m.visitJumpInsn(Opcodes.IFNE, label);
+        };
+        return new Branch(cond, label, ifBranch, elseBranch);
+    }
+
+    @Override
+    public void generate(MethodVisitor visitor, BuildContext context) {
+        branch(Conditional.PUSH_TRUE, Conditional.PUSH_FALSE).generate(visitor, context);
+    }
+
+    @Override
+    public Expression[] getChildren() {
+        return new Expression[]{value};
+    }
+}

--- a/src/main/java/me/august/lumen/compile/parser/ast/expr/StaticField.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/expr/StaticField.java
@@ -5,7 +5,6 @@ import me.august.lumen.compile.analyze.var.VariableReference;
 import me.august.lumen.compile.codegen.BuildContext;
 import me.august.lumen.compile.parser.ast.Typed;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 public class StaticField extends Typed implements VariableExpression {

--- a/src/main/java/me/august/lumen/compile/parser/ast/expr/TernaryExpr.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/expr/TernaryExpr.java
@@ -1,6 +1,14 @@
 package me.august.lumen.compile.parser.ast.expr;
 
-public class TernaryExpr implements Expression {
+import me.august.lumen.compile.codegen.Branch;
+import me.august.lumen.compile.codegen.BuildContext;
+import me.august.lumen.compile.codegen.Conditional;
+import me.august.lumen.compile.codegen.MethodCodeGen;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+
+
+public class TernaryExpr implements Expression, Conditional {
 
     private Expression condition;
 
@@ -23,6 +31,21 @@ public class TernaryExpr implements Expression {
 
     public Expression getFalseExpr() {
         return falseExpr;
+    }
+
+    @Override
+    public Type expressionType() {
+        return trueExpr.expressionType();
+    }
+
+    @Override
+    public Branch branch(MethodCodeGen ifBranch, MethodCodeGen elseBranch) {
+        return ((Conditional) condition).branch(ifBranch, elseBranch);
+    }
+
+    @Override
+    public void generate(MethodVisitor visitor, BuildContext context) {
+        branch(trueExpr, falseExpr).generate(visitor, context);
     }
 
     @Override

--- a/src/main/java/me/august/lumen/compile/parser/ast/expr/TrueExpr.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/expr/TrueExpr.java
@@ -1,5 +1,8 @@
 package me.august.lumen.compile.parser.ast.expr;
 
+import me.august.lumen.compile.codegen.BuildContext;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 public class TrueExpr extends TerminalExpression {
@@ -7,6 +10,11 @@ public class TrueExpr extends TerminalExpression {
     @Override
     public boolean isConstant() {
         return true;
+    }
+
+    @Override
+    public void generate(MethodVisitor visitor, BuildContext context) {
+        visitor.visitInsn(Opcodes.ICONST_1); // load 1 (true)
     }
 
     @Override

--- a/src/main/java/me/august/lumen/compile/parser/ast/stmt/Body.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/stmt/Body.java
@@ -54,11 +54,7 @@ public class Body implements CodeBlock, VisitorConsumer {
             } else if (code instanceof Expression) {
                 ((Expression) code).accept(visitor);
             } else if (code instanceof IfStmt) {
-                IfStmt stmt = (IfStmt) code;
-                stmt.getCondition().accept(visitor);
-                stmt.getTrueBody().accept(visitor);
-                if (stmt.getElseBody() != null)
-                    stmt.getElseBody().accept(visitor);
+                ((IfStmt) code).accept(visitor);
             }
         }
         visitor.visitBodyEnd(this);

--- a/src/main/java/me/august/lumen/compile/parser/ast/stmt/Body.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/stmt/Body.java
@@ -53,6 +53,10 @@ public class Body implements CodeBlock, VisitorConsumer {
                 ((Body) code).accept(visitor);
             } else if (code instanceof Expression) {
                 ((Expression) code).accept(visitor);
+            } else if (code instanceof IfStmt) {
+                IfStmt stmt = (IfStmt) code;
+                stmt.getCondition().accept(visitor);
+                stmt.getTrueBody().accept(visitor);
             }
         }
         visitor.visitBodyEnd(this);

--- a/src/main/java/me/august/lumen/compile/parser/ast/stmt/Body.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/stmt/Body.java
@@ -57,6 +57,8 @@ public class Body implements CodeBlock, VisitorConsumer {
                 IfStmt stmt = (IfStmt) code;
                 stmt.getCondition().accept(visitor);
                 stmt.getTrueBody().accept(visitor);
+                if (stmt.getElseBody() != null)
+                    stmt.getElseBody().accept(visitor);
             }
         }
         visitor.visitBodyEnd(this);

--- a/src/main/java/me/august/lumen/compile/parser/ast/stmt/IfStmt.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/stmt/IfStmt.java
@@ -1,7 +1,10 @@
 package me.august.lumen.compile.parser.ast.stmt;
 
+import me.august.lumen.compile.codegen.BuildContext;
+import me.august.lumen.compile.codegen.Conditional;
 import me.august.lumen.compile.parser.ast.CodeBlock;
 import me.august.lumen.compile.parser.ast.expr.Expression;
+import org.objectweb.asm.MethodVisitor;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,6 +25,28 @@ public class IfStmt implements CodeBlock {
 
     public IfStmt(Expression condition, Body trueBody) {
         this(condition, trueBody, new ArrayList<>(), null);
+    }
+
+    @Override
+    public void generate(MethodVisitor visitor, BuildContext context) {
+        ((Conditional) condition).branch(trueBody, elseBody)
+            .generate(visitor, context);
+    }
+
+    public Expression getCondition() {
+        return condition;
+    }
+
+    public Body getTrueBody() {
+        return trueBody;
+    }
+
+    public List<ElseIf> getElseIfs() {
+        return elseIfs;
+    }
+
+    public Body getElseBody() {
+        return elseBody;
     }
 
     public static class ElseIf {

--- a/src/main/java/me/august/lumen/compile/parser/ast/stmt/IfStmt.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/stmt/IfStmt.java
@@ -1,18 +1,38 @@
 package me.august.lumen.compile.parser.ast.stmt;
 
+import jdk.internal.org.objectweb.asm.Opcodes;
 import me.august.lumen.compile.analyze.ASTVisitor;
 import me.august.lumen.compile.analyze.VisitorConsumer;
 import me.august.lumen.compile.codegen.Branch;
 import me.august.lumen.compile.codegen.BuildContext;
 import me.august.lumen.compile.codegen.Conditional;
+import me.august.lumen.compile.codegen.MethodCodeGen;
 import me.august.lumen.compile.parser.ast.CodeBlock;
 import me.august.lumen.compile.parser.ast.expr.Expression;
+import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.locks.Condition;
 
 public class IfStmt implements CodeBlock, VisitorConsumer {
+
+    private static Branch toBranch(Expression expr, MethodCodeGen ifBranch, MethodCodeGen elseBranch) {
+        if (expr instanceof Conditional) {
+            return ((Conditional) expr).branch(ifBranch, elseBranch);
+        } else if (expr.expressionType().getSort() == Type.BOOLEAN) {
+            Label label = new Label();
+            MethodCodeGen cond = (m, c) -> {
+                expr.generate(m, c);
+                m.visitJumpInsn(Opcodes.IFEQ, label);
+            };
+            return new Branch(cond, label, ifBranch, elseBranch);
+        } else {
+            throw new IllegalArgumentException("Incompatible types.");
+        }
+    }
 
     private Expression condition;
     private Body trueBody;
@@ -32,12 +52,12 @@ public class IfStmt implements CodeBlock, VisitorConsumer {
 
     @Override
     public void generate(MethodVisitor visitor, BuildContext context) {
-        Branch branch = ((Conditional) condition).branch(trueBody, elseBody);
+        Branch branch = toBranch(condition, trueBody, elseBody);
 
         if (elseIfs != null) {
             for (ElseIf elseIf : elseIfs) {
                 branch.setElseBranch(
-                    ((Conditional) elseIf.condition).branch(elseIf.body, branch.getElseBranch())
+                    toBranch(elseIf.condition, elseIf.body, branch.getElseBranch())
                 );
             }
         }

--- a/src/main/java/me/august/lumen/compile/parser/ast/stmt/IfStmt.java
+++ b/src/main/java/me/august/lumen/compile/parser/ast/stmt/IfStmt.java
@@ -1,6 +1,5 @@
 package me.august.lumen.compile.parser.ast.stmt;
 
-import jdk.internal.org.objectweb.asm.Opcodes;
 import me.august.lumen.compile.analyze.ASTVisitor;
 import me.august.lumen.compile.analyze.VisitorConsumer;
 import me.august.lumen.compile.codegen.Branch;
@@ -11,11 +10,11 @@ import me.august.lumen.compile.parser.ast.CodeBlock;
 import me.august.lumen.compile.parser.ast.expr.Expression;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.Condition;
 
 public class IfStmt implements CodeBlock, VisitorConsumer {
 

--- a/src/main/java/me/august/lumen/compile/scanner/Lexer.java
+++ b/src/main/java/me/august/lumen/compile/scanner/Lexer.java
@@ -236,13 +236,13 @@ public class Lexer implements Iterable<Token>, SourcePositionProvider {
             type = IDENTIFIER;
         } else {
             handleKeyword(type);
-            if (ident.equals("is")) {
+            if (ident.equals("is") || ident.equals("isnt")) {
                 consumeWhitespace();
                 Token next = nextToken();
 
                 // next token is identifier with content 'a'
                 if (next.getType() == IDENTIFIER && next.getContent().equals("a")) {
-                    type = INSTANCEOF_KEYWORD;
+                    type = ident.equals("is") ? INSTANCEOF_KEYWORD : NOT_INSTANCEOF_KEYWORD;
                 } else {
                     queued.push(next);
                 }

--- a/src/main/java/me/august/lumen/compile/scanner/Lexer.java
+++ b/src/main/java/me/august/lumen/compile/scanner/Lexer.java
@@ -159,7 +159,7 @@ public class Lexer implements Iterable<Token>, SourcePositionProvider {
             else if (c == '&') return nextAnd();
             else if (c == '~') return token(BIT_COMP);
 
-            else if (c == '!') return nextNegOrNe();
+            else if (c == '!') return nextNotOrNe();
             else if (c == '?') return token(QUESTION);
 
             else if (c == '=') return nextEqOrAssign();
@@ -629,17 +629,17 @@ public class Lexer implements Iterable<Token>, SourcePositionProvider {
      * Precondition: last read char was '!'
      * <p>
      * Differentiates the following tokens:
-     * NEG  "!"  (negate)
+     * NOT  "!"  (not, invert)
      * NE   "!=" (not equal to)
      *
-     * @return The next NEG or NE type token
+     * @return The next NOT or NE type token
      */
-    private Token nextNegOrNe() {
+    private Token nextNotOrNe() {
         if (peek() == '=') {
             read(); // consume '='
             return token(NE);
         }
-        return token(NEG);
+        return token(NOT);
     }
 
     /**

--- a/src/main/java/me/august/lumen/compile/scanner/Type.java
+++ b/src/main/java/me/august/lumen/compile/scanner/Type.java
@@ -76,6 +76,7 @@ public enum Type {
     STATIC_KEYWORD(Attribute.ACC_MOD),
 
     INSTANCEOF_KEYWORD,
+    NOT_INSTANCEOF_KEYWORD,
 
     VAR_KEYWORD,    // declare new local variable
 

--- a/src/main/java/me/august/lumen/compile/scanner/Type.java
+++ b/src/main/java/me/august/lumen/compile/scanner/Type.java
@@ -25,7 +25,7 @@ public enum Type {
     // operators
     // =========
 
-    NEG,        // !
+    NOT,        // !
 
     LOGIC_OR,   // ||
     LOGIC_AND,  // &&

--- a/src/main/java/me/august/lumen/compile/scanner/tokens/StringToken.java
+++ b/src/main/java/me/august/lumen/compile/scanner/tokens/StringToken.java
@@ -9,6 +9,7 @@ public class StringToken extends Token {
 
     public StringToken(String content, QuoteType quoteType, int start, int end) {
         super(content, start, end, Type.STRING);
+        this.quoteType = quoteType;
     }
 
     public QuoteType getQuoteType() {

--- a/src/test/java/me/august/lumen/LexerTest.java
+++ b/src/test/java/me/august/lumen/LexerTest.java
@@ -23,7 +23,7 @@ public class LexerTest {
             L_PAREN, R_PAREN, L_BRACKET, R_BRACKET, L_BRACE, R_BRACE,
             NUMBER, STRING,
             PLUS, MIN, MULT, DIV,
-            NEG, NE,
+            NOT, NE,
             BIT_OR, LOGIC_OR,
             BIT_AND, LOGIC_AND,
             ASSIGN, EQ,


### PR DESCRIPTION
Adds bytecode generation needed for if-statements. Unlike Java, parenthesis are not needed around the conditional:

```
if foo == bar {
    ...
}
```

If the body is one expression, the <kbd>then</kbd> keyword can be used (with braces omitted):

```
if foo == bar then System::out.println("equal")
```